### PR TITLE
Harden bootstrapdocs command execution

### DIFF
--- a/doc/source/bootstrapdocs.py
+++ b/doc/source/bootstrapdocs.py
@@ -7,7 +7,7 @@ RST_GENERATION_SCRIPT = 'htmlgen'
 script_path = os.path.join(os.path.dirname(__file__),
                            RST_GENERATION_SCRIPT)
 os.environ['PATH'] += ':.'
-rc = subprocess.call("python "+ script_path, shell=True, env=os.environ)
+rc = subprocess.call([sys.executable, script_path], env=os.environ)
 if rc != 0:
     sys.stderr.write("Failed to generate documentation!\n")
     sys.exit(2)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"99ee6058-b014-4f60-a070-f4e1e87a73f8","source":"chat","resourceId":"d2cc935c-3680-4649-926c-5c5241ecfe94","workflowId":"55594521-9e2c-4ae2-b80c-8235bf9c0897","codeChangeId":"55594521-9e2c-4ae2-b80c-8235bf9c0897","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/032c5c2e1811a0966c8166400ce9d5a8?panel_event_id=AwAAAZ8jswaspEcYxgAAABhBWjhqc3dhc0FBQVRzemx5ejhETVFjWlcAAAAkZjE5ZjIzYjYtMDdlNi00ZDc5LWI0MWItNzdhZTI3MTNkNmU2AABBJg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDMyYzVjMmUxODExYTA5NjZjODE2NjQwMGNlOWQ1YTh-YjJkYzg2ZjQyMTJmZDBhNzc0N2VhM2MwZGVmMDY0OGQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Faws-cli%22+%22Potential+command+injection%22)

Address a high-severity SAST command injection risk in doc/source/bootstrapdocs.py where a shell command string was built and executed with shell=True.

## Changes
- Replaced string-based subprocess invocation with argument-list invocation.
- Switched from "python <script>" shell execution to [sys.executable, script_path] to avoid shell parsing and interpreter hijacking risks from command-string execution.
- Preserved existing behavior and environment passing for docs generation.

## Testing
- Ran: python -m py_compile doc/source/bootstrapdocs.py
- Verified the updated call site no longer uses shell=True and still invokes the same script path.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/d2cc935c-3680-4649-926c-5c5241ecfe94)

Comment @datadog to request changes